### PR TITLE
Fix top categories expenses response

### DIFF
--- a/app/Containers/AppSection/Category/UI/API/Controllers/GetTopCategoriesExpensesController.php
+++ b/app/Containers/AppSection/Category/UI/API/Controllers/GetTopCategoriesExpensesController.php
@@ -13,10 +13,14 @@ class GetTopCategoriesExpensesController extends ApiController
     /**
      * @throws InvalidTransformerException
      */
-    public function __invoke(GetTopCategoriesExpensesRequest $request, GetTopCategoriesExpensesAction $action): array
+    public function __invoke(GetTopCategoriesExpensesRequest $request, GetTopCategoriesExpensesAction $action): mixed
     {
         $categories = $action->run($request);
 
-        return $this->transform($categories, CategoryExpenseTransformer::class);
+        return response()->json(
+            fractal()
+                ->collection($categories, new CategoryExpenseTransformer())
+                ->toArray()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- fix the GetTopCategoriesExpensesController to transform using fractal

## Testing
- `./vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b196a23c8320957b4129ff12fa9e