### PR TITLE
Add unioned recent transactions

### DIFF
--- a/app/Containers/AppSection/Transaction/Tasks/GetRecentTransactionsTask.php
+++ b/app/Containers/AppSection/Transaction/Tasks/GetRecentTransactionsTask.php
@@ -10,7 +10,23 @@ class GetRecentTransactionsTask extends ParentTask
     public function run(): mixed
     {
         return DB::table('expenses')
-            ->select('expense', 'amount')
+            ->select([
+                'expense as name',
+                'amount',
+                'date',
+                DB::raw("'expense' as transaction_type"),
+            ])
+            ->unionAll(
+                DB::table('incomes')
+                    ->select([
+                        'income as name',
+                        'amount',
+                        'date',
+                        DB::raw("'income' as transaction_type"),
+                    ])
+            )
+            ->orderByDesc('date')
+            ->limit(5)
             ->get();
     }
 }

--- a/app/Containers/AppSection/Transaction/UI/API/Transformers/TransactionTransformer.php
+++ b/app/Containers/AppSection/Transaction/UI/API/Transformers/TransactionTransformer.php
@@ -2,7 +2,6 @@
 
 namespace App\Containers\AppSection\Transaction\UI\API\Transformers;
 
-use App\Containers\AppSection\Transaction\Models\;
 use App\Ship\Parents\Transformers\Transformer as ParentTransformer;
 
 class TransactionTransformer extends ParentTransformer
@@ -11,15 +10,13 @@ class TransactionTransformer extends ParentTransformer
 
     protected array $availableIncludes = [];
 
-    public function transform( $): array
+    public function transform(object $transaction): array
     {
         return [
-            'object' => $->getResourceKey(),
-            'id' => $->getHashedKey(),
-            'created_at' => $->created_at,
-            'updated_at' => $->updated_at,
-            'readable_created_at' => $->created_at->diffForHumans(),
-            'readable_updated_at' => $->updated_at->diffForHumans(),
+            'name' => $transaction->name,
+            'amount' => (float) $transaction->amount,
+            'date' => $transaction->date,
+            'transaction_type' => $transaction->transaction_type,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- fetch the 5 latest incomes and expenses together
- expose transaction type in API transformer

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e5cc55248320b4f319158d212333