### PR TITLE
Add API to filter expenses by date and type

### DIFF
--- a/app/Containers/AppSection/Expense/Actions/ListExpensesByMonthYearAndTypeAction.php
+++ b/app/Containers/AppSection/Expense/Actions/ListExpensesByMonthYearAndTypeAction.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Containers\AppSection\Expense\Actions;
+
+use Apiato\Core\Exceptions\CoreInternalErrorException;
+use App\Containers\AppSection\Expense\Tasks\ListExpensesByMonthYearAndTypeTask;
+use App\Containers\AppSection\Expense\UI\API\Requests\ListExpensesByMonthYearAndTypeRequest;
+use App\Ship\Parents\Actions\Action as ParentAction;
+use Prettus\Repository\Exceptions\RepositoryException;
+
+class ListExpensesByMonthYearAndTypeAction extends ParentAction
+{
+    public function __construct(
+        private readonly ListExpensesByMonthYearAndTypeTask $listExpensesByMonthYearAndTypeTask,
+    ) {}
+
+    /**
+     * @throws CoreInternalErrorException
+     * @throws RepositoryException
+     */
+    public function run(ListExpensesByMonthYearAndTypeRequest $request): mixed
+    {
+        return $this->listExpensesByMonthYearAndTypeTask->run(
+            (int) $request->year,
+            (int) $request->month,
+            (int) $request->type_id
+        );
+    }
+}

--- a/app/Containers/AppSection/Expense/Tasks/ListExpensesByMonthYearAndTypeTask.php
+++ b/app/Containers/AppSection/Expense/Tasks/ListExpensesByMonthYearAndTypeTask.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Containers\AppSection\Expense\Tasks;
+
+use Apiato\Core\Exceptions\CoreInternalErrorException;
+use App\Containers\AppSection\Expense\Data\Repositories\ExpenseRepository;
+use App\Ship\Parents\Tasks\Task as ParentTask;
+use Prettus\Repository\Exceptions\RepositoryException;
+
+class ListExpensesByMonthYearAndTypeTask extends ParentTask
+{
+    public function __construct(
+        private readonly ExpenseRepository $repository,
+    ) {}
+
+    /**
+     * @throws CoreInternalErrorException
+     * @throws RepositoryException
+     */
+    public function run(int $year, int $month, int $typeId): mixed
+    {
+        return $this->repository
+            ->whereYear('date', $year)
+            ->whereMonth('date', $month)
+            ->where('type_id', $typeId)
+            ->get();
+    }
+}

--- a/app/Containers/AppSection/Expense/UI/API/Controllers/ListExpensesByMonthYearAndTypeController.php
+++ b/app/Containers/AppSection/Expense/UI/API/Controllers/ListExpensesByMonthYearAndTypeController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Containers\AppSection\Expense\UI\API\Controllers;
+
+use Apiato\Core\Exceptions\CoreInternalErrorException;
+use Apiato\Core\Exceptions\InvalidTransformerException;
+use App\Containers\AppSection\Expense\Actions\ListExpensesByMonthYearAndTypeAction;
+use App\Containers\AppSection\Expense\UI\API\Requests\ListExpensesByMonthYearAndTypeRequest;
+use App\Containers\AppSection\Expense\UI\API\Transformers\ExpenseTransformer;
+use App\Ship\Parents\Controllers\ApiController;
+use Prettus\Repository\Exceptions\RepositoryException;
+
+class ListExpensesByMonthYearAndTypeController extends ApiController
+{
+    /**
+     * @throws InvalidTransformerException
+     * @throws CoreInternalErrorException
+     * @throws RepositoryException
+     */
+    public function __invoke(ListExpensesByMonthYearAndTypeRequest $request, ListExpensesByMonthYearAndTypeAction $action): mixed
+    {
+        $expenses = $action->run($request);
+
+        return response()->json(
+            fractal()
+                ->collection($expenses, new ExpenseTransformer())
+                ->toArray()
+        );
+    }
+}

--- a/app/Containers/AppSection/Expense/UI/API/Requests/ListExpensesByMonthYearAndTypeRequest.php
+++ b/app/Containers/AppSection/Expense/UI/API/Requests/ListExpensesByMonthYearAndTypeRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Containers\AppSection\Expense\UI\API\Requests;
+
+use App\Ship\Parents\Requests\Request as ParentRequest;
+
+class ListExpensesByMonthYearAndTypeRequest extends ParentRequest
+{
+    protected array $access = [
+        'permissions' => null,
+        'roles' => null,
+    ];
+
+    protected array $decode = [
+        'type_id',
+    ];
+
+    protected array $urlParameters = [
+        'year',
+        'month',
+        'type_id',
+    ];
+
+    public function rules(): array
+    {
+        return [
+            'type_id' => 'required|exists:types,id',
+            'month' => 'required|integer|between:1,12',
+            'year' => 'required|integer|min:2000',
+        ];
+    }
+
+    public function authorize(): bool
+    {
+        return $this->check([
+            'hasAccess',
+        ]);
+    }
+}

--- a/app/Containers/AppSection/Expense/UI/API/Routes/ListExpensesByMonthYearAndType.v1.private.php
+++ b/app/Containers/AppSection/Expense/UI/API/Routes/ListExpensesByMonthYearAndType.v1.private.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @apiGroup           Expense
+ * @apiName            ListExpensesByMonthYearAndType
+ *
+ * @api                {GET} /v1/expenses/by-type/{type_id}/{year}/{month} List Expenses By Month Year And Type
+ * @apiDescription     Get expenses filtered by month, year and type
+ *
+ * @apiVersion         1.0.0
+ * @apiPermission      Authenticated ['permissions' => '', 'roles' => '']
+ *
+ * @apiHeader          {String} accept=application/json
+ * @apiHeader          {String} authorization=Bearer
+ *
+ * @apiParam           {String} type_id Type identifier
+ * @apiParam           {Integer} year Year (e.g., 2024)
+ * @apiParam           {Integer} month Month number (1-12)
+ *
+ * @apiSuccessExample  {json} Success-Response:
+ * HTTP/1.1 200 OK
+ * {
+ *     "data": []
+ * }
+ */
+
+use App\Containers\AppSection\Expense\UI\API\Controllers\ListExpensesByMonthYearAndTypeController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('expenses/by-type/{type_id}/{year}/{month}', ListExpensesByMonthYearAndTypeController::class)
+    ->middleware(['auth:api']);


### PR DESCRIPTION
## Summary
- add task to filter expenses by month, year and type
- add action wrapping the new task
- create request and controller for the new endpoint
- register route `/expenses/by-type/{type_id}/{year}/{month}`

## Testing
- `phpunit -c phpunit.xml --stop-on-failure` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5ef528348320af75a6ec9f900bb1