### PR TITLE
Add monthly summary API

### DIFF
--- a/app/Containers/AppSection/Objective/Tasks/GetTotalSavedAmountTask.php
+++ b/app/Containers/AppSection/Objective/Tasks/GetTotalSavedAmountTask.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Containers\AppSection\Objective\Tasks;
+
+use App\Containers\AppSection\Objective\Data\Repositories\ObjectiveRepository;
+use App\Ship\Parents\Tasks\Task as ParentTask;
+
+class GetTotalSavedAmountTask extends ParentTask
+{
+    public function __construct(
+        private readonly ObjectiveRepository $repository,
+    ) {}
+
+    public function run(): float
+    {
+        return (float) $this->repository->sum('saved_amount');
+    }
+}

--- a/app/Containers/AppSection/Transaction/Actions/GetMonthlySummaryAction.php
+++ b/app/Containers/AppSection/Transaction/Actions/GetMonthlySummaryAction.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Containers\AppSection\Transaction\Actions;
+
+use Apiato\Core\Exceptions\CoreInternalErrorException;
+use App\Containers\AppSection\Transaction\UI\API\Requests\GetMonthlySummaryRequest;
+use App\Containers\AppSection\Expense\Tasks\ListExpensesByMonthTask;
+use App\Containers\AppSection\Income\Tasks\ListIncomesByMonthTask;
+use App\Containers\AppSection\Objective\Tasks\GetTotalSavedAmountTask;
+use App\Ship\Parents\Actions\Action as ParentAction;
+use Prettus\Repository\Exceptions\RepositoryException;
+
+class GetMonthlySummaryAction extends ParentAction
+{
+    public function __construct(
+        private readonly ListExpensesByMonthTask $listExpensesByMonthTask,
+        private readonly ListIncomesByMonthTask $listIncomesByMonthTask,
+        private readonly GetTotalSavedAmountTask $getTotalSavedAmountTask,
+    ) {}
+
+    /**
+     * @throws CoreInternalErrorException
+     * @throws RepositoryException
+     */
+    public function run(GetMonthlySummaryRequest $request): array
+    {
+        $expenses = $this->listExpensesByMonthTask->run($request->year, $request->month);
+        $incomes = $this->listIncomesByMonthTask->run($request->month);
+
+        $totalExpenses = 0;
+        foreach ($expenses as $expense) {
+            $monthlyAmount = $expense->installments > 1 ? $expense->amount / $expense->installments : $expense->amount;
+            $totalExpenses += $monthlyAmount;
+        }
+
+        $totalIncomes = 0;
+        foreach ($incomes as $income) {
+            $totalIncomes += $income->amount;
+        }
+
+        $savedAmount = $this->getTotalSavedAmountTask->run();
+
+        return [
+            'total_expenses' => round($totalExpenses, 2),
+            'total_incomes' => round($totalIncomes, 2),
+            'total_savings' => round($savedAmount, 2),
+            'balance' => round($totalIncomes - $totalExpenses, 2),
+        ];
+    }
+}

--- a/app/Containers/AppSection/Transaction/UI/API/Controllers/GetMonthlySummaryController.php
+++ b/app/Containers/AppSection/Transaction/UI/API/Controllers/GetMonthlySummaryController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Containers\AppSection\Transaction\UI\API\Controllers;
+
+use Apiato\Core\Exceptions\CoreInternalErrorException;
+use Apiato\Core\Exceptions\InvalidTransformerException;
+use App\Containers\AppSection\Transaction\Actions\GetMonthlySummaryAction;
+use App\Containers\AppSection\Transaction\UI\API\Requests\GetMonthlySummaryRequest;
+use App\Containers\AppSection\Transaction\UI\API\Transformers\MonthlySummaryTransformer;
+use App\Ship\Parents\Controllers\ApiController;
+use Prettus\Repository\Exceptions\RepositoryException;
+
+class GetMonthlySummaryController extends ApiController
+{
+    /**
+     * @throws InvalidTransformerException
+     * @throws CoreInternalErrorException
+     * @throws RepositoryException
+     */
+    public function GetMonthlySummary(GetMonthlySummaryRequest $request, GetMonthlySummaryAction $action): mixed
+    {
+        $summary = $action->run($request);
+
+        return response()->json(
+            fractal()->item($summary, new MonthlySummaryTransformer())->toArray()
+        );
+    }
+}

--- a/app/Containers/AppSection/Transaction/UI/API/Requests/GetMonthlySummaryRequest.php
+++ b/app/Containers/AppSection/Transaction/UI/API/Requests/GetMonthlySummaryRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Containers\AppSection\Transaction\UI\API\Requests;
+
+use App\Ship\Parents\Requests\Request as ParentRequest;
+
+class GetMonthlySummaryRequest extends ParentRequest
+{
+    protected array $access = [
+        'permissions' => null,
+        'roles' => null,
+    ];
+
+    protected array $decode = [];
+
+    protected array $urlParameters = [
+        'year',
+        'month',
+    ];
+
+    public function rules(): array
+    {
+        return [];
+    }
+
+    public function authorize(): bool
+    {
+        return $this->check([
+            'hasAccess',
+        ]);
+    }
+}

--- a/app/Containers/AppSection/Transaction/UI/API/Routes/GetMonthlySummaryRoute.v1.private.php
+++ b/app/Containers/AppSection/Transaction/UI/API/Routes/GetMonthlySummaryRoute.v1.private.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @apiGroup           Transaction
+ * @apiName            GetMonthlySummary
+ *
+ * @api                {GET} /v1/monthly-summary/:year/:month Get Monthly Summary
+ * @apiDescription     Endpoint to retrieve monthly totals for expenses, incomes and savings
+ *
+ * @apiVersion         1.0.0
+ * @apiPermission      Authenticated ['permissions' => '', 'roles' => '']
+ *
+ * @apiHeader          {String} accept=application/json
+ * @apiHeader          {String} authorization=Bearer
+ *
+ * @apiParam           {String} parameters here...
+ *
+ * @apiSuccessExample  {json} Success-Response:
+ * HTTP/1.1 200 OK
+ * {
+ *     // Insert the response of the request here...
+ * }
+ */
+
+use App\Containers\AppSection\Transaction\UI\API\Controllers\GetMonthlySummaryController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('monthly-summary/{year}/{month}', [GetMonthlySummaryController::class, 'GetMonthlySummary'])
+    ->middleware(['auth:api']);

--- a/app/Containers/AppSection/Transaction/UI/API/Transformers/MonthlySummaryTransformer.php
+++ b/app/Containers/AppSection/Transaction/UI/API/Transformers/MonthlySummaryTransformer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Containers\AppSection\Transaction\UI\API\Transformers;
+
+use App\Ship\Parents\Transformers\Transformer as ParentTransformer;
+
+class MonthlySummaryTransformer extends ParentTransformer
+{
+    public function transform(array $data): array
+    {
+        return [
+            'total_expenses' => $data['total_expenses'],
+            'total_incomes'  => $data['total_incomes'],
+            'total_savings'  => $data['total_savings'],
+            'balance'        => $data['balance'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add action to aggregate monthly expenses, incomes and savings
- expose new MonthlySummary API endpoint with request/controller/transformer
- support retrieving total saved amount from objectives
- move monthly summary logic to Transaction container

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686313e79d248320ae1783db5f2e980c